### PR TITLE
Make install directions more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Installation
         $ cd /home/redmine/redmine-${version}/plugins
         $ git clone https://github.com/paginagmbh/redmine_emojibutton.git
 
- 2. Run bundler (from the plugin directory):
+ 2. Run bundler (from the **plugin directory**, e.g. `/home/redmine/redmine-${version}/plugins/redmine_emojibutton`):
 
         $ bundle install
 
- 3. Run rake task (from the Redmine root directory):
+ 3. Run rake task (from the **Redmine root directory**, e.g. `/home/redmine/redmine-${version}`):
 
         $ rake emoji
 


### PR DESCRIPTION
I mistakenly ran `rake emoji` from the plugin directory. I see from the issue queue others have too. Hopefully this makes it more clear to others in the future.