### PR TITLE
Support Redmine version 4.x which runs on Rails 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This plugin enables github style emoji notation in textile formatter and adds a 
 Compatibility
 -------------
 
-The latest version supports Redmine **2.6.x** as well as **3.x**
+The latest version supports Redmine **2.6.x** as well as **3.x** and **4.x**
 
 
 

--- a/lib/emojibutton_helper_patch.rb
+++ b/lib/emojibutton_helper_patch.rb
@@ -22,7 +22,12 @@ module EmojiButtonPlugin
         base.send(:include, HelperMethodsWikiExtensions)
         base.class_eval do
           unloadable # Send unloadable so it will not be unloaded in development  
-          alias_method_chain :heads_for_wiki_formatter, :redmine_emojibutton
+          if Rails.version < '5.0.0'
+            alias_method_chain :heads_for_wiki_formatter, :redmine_emojibutton
+          else
+            alias_method :heads_for_wiki_formatter_without_redmine_emojibutton, :heads_for_wiki_formatter
+            alias_method :heads_for_wiki_formatter, :heads_for_wiki_formatter_with_redmine_emojibutton
+          end
         end
       end
     end


### PR DESCRIPTION
Redmine v 4.x now runs on Rails 5. Since Rails 5 drops support for `alias_chain_method` we need a bit of a work around. We could eventually move to [prepend](https://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/) but to continue supporting older versions, I figured this work around would be fine for now.