### PR TITLE
Use prepend instead of alias_method to fix compatibility

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -33,7 +33,7 @@ Rails.configuration.to_prepare do
     end
 
     unless Redmine::WikiFormatting::helper_for(format).included_modules.include? EmojiButtonPlugin::Helper::Patch
-     Redmine::WikiFormatting::helper_for(format).send(:include, EmojiButtonPlugin::Helper::Patch)
+     Redmine::WikiFormatting::helper_for(format).prepend EmojiButtonPlugin::Helper::Patch
     end
   end
 end

--- a/lib/emojibutton_helper_patch.rb
+++ b/lib/emojibutton_helper_patch.rb
@@ -18,25 +18,10 @@
 module EmojiButtonPlugin
   module Helper
     module Patch
-      def self.included(base) # :nodoc:
-        base.send(:include, HelperMethodsWikiExtensions)
-        base.class_eval do
-          unloadable # Send unloadable so it will not be unloaded in development
-          if Rails.version < '5.0.0'
-            alias_method_chain :heads_for_wiki_formatter, :redmine_emojibutton
-          else
-            alias_method :heads_for_wiki_formatter_without_redmine_emojibutton, :heads_for_wiki_formatter
-            alias_method :heads_for_wiki_formatter, :heads_for_wiki_formatter_with_redmine_emojibutton
-          end
-        end
-      end
-    end
+      private
 
-    private
-
-    module HelperMethodsWikiExtensions
-      def heads_for_wiki_formatter_with_redmine_emojibutton
-        heads_for_wiki_formatter_without_redmine_emojibutton
+      def heads_for_wiki_formatter
+        super
         return if ie6_or_ie7?
 
         unless @heads_for_wiki_redmine_emojibutton_included
@@ -50,7 +35,7 @@ module EmojiButtonPlugin
             unless settings.empty?
               o << javascript_tag(settings)
             end
-            
+
             o << javascript_include_tag('emojibutton_plugin.js', :plugin => 'redmine_emojibutton')
             o << stylesheet_link_tag('emojibutton_plugin.css', :plugin => 'redmine_emojibutton')
 
@@ -59,8 +44,6 @@ module EmojiButtonPlugin
           @heads_for_wiki_redmine_emojibutton_included = true
         end
       end
-
-      private
 
       def ie6_or_ie7?
         useragent = request.env['HTTP_USER_AGENT'].to_s

--- a/lib/emojibutton_helper_patch.rb
+++ b/lib/emojibutton_helper_patch.rb
@@ -18,8 +18,6 @@
 module EmojiButtonPlugin
   module Helper
     module Patch
-      private
-
       def heads_for_wiki_formatter
         super
         return if ie6_or_ie7?
@@ -44,6 +42,8 @@ module EmojiButtonPlugin
           @heads_for_wiki_redmine_emojibutton_included = true
         end
       end
+
+      private
 
       def ie6_or_ie7?
         useragent = request.env['HTTP_USER_AGENT'].to_s


### PR DESCRIPTION
Hi, 

with this PR alias_method is drop and prepend is used, to get compatibility to other plugins.

I am the author of [additionals](https://github.com/AlphaNodes/additionals) plugin and I also have emoji support in this plugin. Because I also wanted to use same Gemoji 4 technique, I want to drop emoji support and want to use your great plugin instead.

Problem is, that I use prepend for the same helper for other functionality and this conflicts with your plugin. If you would also use prepend, both plugins can be used together. 

Some information about prepend: https://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/